### PR TITLE
Initial commits -- basic Helm chart for app of apps

### DIFF
--- a/.github/workflow/pullrequest.yaml
+++ b/.github/workflow/pullrequest.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HELM_VERSION: "v3.3.4"
-
+      HELM_CHECKSUM: "b664632683c36446deeb85c406871590d879491e3de18978b426769e43a1e82c"
     steps:
     - name: Checkout
       uses: actions/checkout@v1
@@ -14,7 +14,7 @@ jobs:
       run: |
         curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm-${HELM_VERSION}-linux-amd64.tar.gz \
         && curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum -o helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum \
-        sha256sum -c helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum \
+        && echo "${HELM_CHECKSUM} helm-${HELM_VERSION}-linux-amd64.tar.gz" | sha256sum -c \
         && sudo mv -v linux-amd64/helm /usr/local/bin/helm \
         && rm -vrf linux-amd64
     - name: SHA check

--- a/.github/workflow/pullrequest.yaml
+++ b/.github/workflow/pullrequest.yaml
@@ -5,17 +5,19 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     env:
-      HELM_VERSION: "v3.3.2"
+      HELM_VERSION: "v3.3.4"
 
     steps:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Helm Install
       run: |
-        curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz \
-          | tar vxz \
-            && sudo mv -v linux-amd64/helm /usr/local/bin/helm \
-            && rm -vrf linux-amd64
+        curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm-${HELM_VERSION}-linux-amd64.tar.gz \
+        && curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum -o helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum \
+        sha256sum -c helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum \
+        && sudo mv -v linux-amd64/helm /usr/local/bin/helm \
+        && rm -vrf linux-amd64
+    - name: SHA check
     - name: Lint
       run: helm lint .
     - name: Should template test1

--- a/.github/workflow/pullrequest.yaml
+++ b/.github/workflow/pullrequest.yaml
@@ -1,0 +1,24 @@
+---
+name: CI
+on: [pull_request]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    env:
+      HELM_VERSION: "v3.3.2"
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Helm Install
+      run: |
+        curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz \
+          | tar vxz \
+            && sudo mv -v linux-amd64/helm /usr/local/bin/helm \
+            && rm -vrf linux-amd64
+    - name: Lint
+      run: helm lint .
+    - name: Should template test1
+      run: |
+        helm template . --values tests/appofapps_test1.yaml
+

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: appofapps
+description: a Helm chart that follows the app of apps pattern
+type: application
+version: 0.0.1
+appVersion: 0.0.1

--- a/Notes.md
+++ b/Notes.md
@@ -1,0 +1,9 @@
+# Notes
+
+## CI
+
+Github actions inspired by: https://github.com/evry-ace/helm-charts
+
+## Ideas
+
+We could add tests as yaml values with corresponding expected outcomes.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# helm-argocd-appofapps
-A helm chart
+# Helm App of Apps Chart
+
+A helm chart that mimicks the app of apps patterns with some features.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "appofapps.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "appofapps.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "appofapps.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "appofapps.labels" -}}
+helm.sh/chart: {{ include "appofapps.chart" . }}
+{{ include "appofapps.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "appofapps.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "appofapps.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "appofapps.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "appofapps.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/templates/application.yaml
+++ b/templates/application.yaml
@@ -16,9 +16,9 @@ spec:
     namespace: default
   project: default
   source:
-    chart: {{ $.Values.remoteChart.name | default "prometheus" }}
-    repoURL: {{ $.Values.remoteChart.repo | default "https://kubernetes-charts.storage.googleapis.com" }}
-    targetRevision: {{ $.Values.remoteChart.revision | default "11.12.0" }}
+    chart: {{ $.Values.remoteChart.name }}
+    repoURL: {{ $.Values.remoteChart.repo }}
+    targetRevision: {{ $.Values.remoteChart.revision }}
     {{- if $.Values.remoteChart.values }}
     helm:
       values: {{ nindent 7 (toYaml $.Values.remoteChart.values) }}

--- a/templates/application.yaml
+++ b/templates/application.yaml
@@ -13,8 +13,8 @@ metadata:
 spec:
   destination:
     server: {{ $cluster_address | quote }}
-    namespace: default
-  project: default
+    namespace: {{ $.Values.remoteChart.namespace }}
+  project: {{ $.Values.projectName }}
   source:
     chart: {{ $.Values.remoteChart.name }}
     repoURL: {{ $.Values.remoteChart.repo }}
@@ -23,12 +23,10 @@ spec:
     helm:
       values: {{ nindent 7 (toYaml $.Values.remoteChart.values) }}
     {{- end }}
-  {{- if $.Values.autosync }}
   syncPolicy:
     automated:
-      prune: true
-      selfHeal: true
-  {{- end }}
+      prune: {{ $.Values.syncPolicy.prune }}
+      selfHeal: {{ $.Values.syncPolicy.selfHeal }}
 {{- if $.Values.sequential }}
 {{- $wave_counter = add1 ($wave_counter) }}
 {{- end }}

--- a/templates/application.yaml
+++ b/templates/application.yaml
@@ -1,0 +1,35 @@
+{{- $dot := . }}
+{{- $wave_counter := 0 }}
+{{- range $cluster_name, $cluster_address := .Values.clusters }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ include "appofapps.name" $dot }}-{{ $cluster_name }}
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $wave_counter | quote }} 
+  labels: {{ nindent 3 (include "appofapps.labels" $dot) }}
+spec:
+  destination:
+    server: {{ $cluster_address | quote }}
+    namespace: default
+  project: default
+  source:
+    chart: {{ $.Values.remoteChart.name | default "prometheus" }}
+    repoURL: {{ $.Values.remoteChart.repo | default "https://kubernetes-charts.storage.googleapis.com" }}
+    targetRevision: {{ $.Values.remoteChart.revision | default "11.12.0" }}
+    {{- if $.Values.remoteChart.values }}
+    helm:
+      values: {{ nindent 7 (toYaml $.Values.remoteChart.values) }}
+    {{- end }}
+  {{- if $.Values.autosync }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  {{- end }}
+{{- if $.Values.sequential }}
+{{- $wave_counter = add1 ($wave_counter) }}
+{{- end }}
+{{- end }}

--- a/tests/appofapps_test1.yaml
+++ b/tests/appofapps_test1.yaml
@@ -1,5 +1,6 @@
 remoteChart:
   name: "prometheus"
+  namespace: "target_namespace"
   repo: "https://kubernetes-charts.storage.googleapis.com"
   revision: "11.12.0"
   values:

--- a/tests/appofapps_test1.yaml
+++ b/tests/appofapps_test1.yaml
@@ -1,0 +1,13 @@
+remoteChart:
+  name: "prometheus"
+  repo: "https://kubernetes-charts.storage.googleapis.com"
+  revision: "11.12.0"
+  values:
+    key1: 'value1'
+    key2:
+      test1: 'val1'
+      test2: 'val2'
+autosync: true
+clusters:
+  cluster1: 'http://addr1:1234'
+  cluster2: 'http://addr2:3456'

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,20 @@
+# Default values for appofapps
+
+# clusters is a dictionary listing the target clusters
+# clusters:
+#   cluster1: 'https://cluster1-addr1:por1'
+#   cluster2: 'https://cluster2-addr2:por2'
+clusters: {}
+
+# the applications will automatically sync
+autosync: true
+
+# the clusters will be rolled out one after the other
+sequential: true
+
+remoteChart:
+  name: "prometheus"
+  repo: "https://kubernetes-charts.storage.googleapis.com"
+  revision: "11.12.0"
+  values: {}
+

--- a/values.yaml
+++ b/values.yaml
@@ -13,8 +13,8 @@ autosync: true
 sequential: true
 
 remoteChart:
-  name: "prometheus"
-  repo: "https://kubernetes-charts.storage.googleapis.com"
-  revision: "11.12.0"
-  values: {}
+  name: ""      # Chart name to deploy in the remote clusters
+  revision: ""  # Chart revision
+  repo: ""      # Repository where the chart lives
+  values: {}    # Values to pass on to the chart on the remote clusters
 

--- a/values.yaml
+++ b/values.yaml
@@ -6,15 +6,20 @@
 #   cluster2: 'https://cluster2-addr2:por2'
 clusters: {}
 
+# project name
+projectName: "default"
+
 # the applications will automatically sync
-autosync: true
+syncPolicy:
+  prune: true
+  selfHeal: true
 
 # the clusters will be rolled out one after the other
 sequential: true
 
 remoteChart:
-  name: ""      # Chart name to deploy in the remote clusters
-  revision: ""  # Chart revision
-  repo: ""      # Repository where the chart lives
-  values: {}    # Values to pass on to the chart on the remote clusters
-
+  name: ""              # Chart name to deploy in the remote clusters
+  revision: ""          # Chart revision
+  repo: ""              # Repository where the chart lives
+  namespace: "default"  # target Namespace
+  values: {}            # Values to pass on to the chart on the remote clusters


### PR DESCRIPTION
This commit gets us started.
The helm chart is generating application objects from a map of cluster
names and their corresponding endpoints.

There are only two options at the moment:
- `sequential`: applications will be rolled out one cluster after the
others.
- `parallel`: applications will be rolled out across clusters at the same
time.

We use sync wave to orchestrate the deployments.

This PR also embeds a limited testing + a github action configuration that would run lining.
Again this is simply to get us going.