### PR TITLE
Typo in Application CRD

### DIFF
--- a/templates/application.yaml
+++ b/templates/application.yaml
@@ -21,7 +21,7 @@ spec:
     targetRevision: {{ $.Values.remoteChart.revision }}
     {{- if $.Values.remoteChart.values }}
     helm:
-      values: {{ nindent 7 (toYaml $.Values.remoteChart.values) }}
+      values: | {{ nindent 7 (toYaml $.Values.remoteChart.values) }}
     {{- end }}
   syncPolicy:
     automated:


### PR DESCRIPTION
the helm values need to be passed as a string.
There is value is getting it as an object and unmarshall/marshall it
first before passing it as a string to the application.